### PR TITLE
Allow configuration of Encryption Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This module creates a complete Langfuse stack with the following components:
 | vpc_cidr | CIDR block for VPC | string | "10.0.0.0/16" | no |
 | use_single_nat_gateway | To use a single NAT Gateway (cheaper) or one per AZ (more resilient) | bool | true | no |
 | kubernetes_version | Kubernetes version for EKS cluster | string | "1.32" | no |
+| use_encryption_key | Wheter or not to use an Encryption key for LLM API credential and integration credential store | bool | false | no |
 | fargate_profile_namespaces | List of namespaces to create Fargate profiles for | list(string) | ["default", "langfuse", "kube-system"] | no |
 | postgres_instance_count | Number of PostgreSQL instances | number | 2 | no |
 | postgres_min_capacity | Minimum ACU capacity for PostgreSQL Serverless v2 | number | 0.5 | no |

--- a/examples/quickstart/quickstart.tf
+++ b/examples/quickstart/quickstart.tf
@@ -7,6 +7,9 @@ module "langfuse" {
   # e.g. when using the module multiple times on the same AWS account
   name = "langfuse"
 
+  # Optional: Configure Langfuse
+  use_encryption_key = true # Enable encryption for sensitive data stored in Langfuse
+
   # Optional: Configure the VPC
   vpc_cidr               = "10.0.0.0/16"
   use_single_nat_gateway = false # Using a single NAT gateway decreases costs, but is less resilient

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "kubernetes_version" {
   default     = "1.32"
 }
 
+variable "use_encryption_key" {
+  description = "Wheter or not to use an Encryption key for LLM API credential and integration credential store"
+  type        = bool
+  default     = false
+}
+
 variable "postgres_instance_count" {
   description = "Number of PostgreSQL instances to create"
   type        = number


### PR DESCRIPTION
This PR adds the possibility to enable using an encryption key, which is used to encrypt sensitive data: https://langfuse.com/self-hosting/encryption