### PR TITLE
FIX: Zookeeper OOM kills due to insufficient memory limits

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -35,6 +35,14 @@ clickhouse:
   auth:
     existingSecret: langfuse
     existingSecretKey: clickhouse-password
+  zookeeper:
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "250m"
+      limits:
+        memory: "1536Mi"
+        cpu: "500m"
 redis:
   deploy: false
   host: ${aws_elasticache_replication_group.redis.primary_endpoint_address}


### PR DESCRIPTION
Was getting OOM restarts on zookeeper pods (functional but constant eventual crashes).

The bitnami clickhouse chart defaults zookeeper.resourcesPreset to micro, which is a 384Mi memory limit. It's underlying zookeeper chart sets the JVM max heap to 1024. I think JVM was continuing to grow memory usage until eventually hitting container limit, triggering a OOM error and restart, and this was happening repeatedly.

This bumps the container limit to 1536Mi to allow the full JVM heap + headroom. 

As far as i can see the flow is:
Langfuse Chart
  ↓ (dependency)
Bitnami ClickHouse Chart v8.0.5
  ↓ (sets: zookeeper.resourcesPreset: "micro") 
Bitnami Zookeeper Chart v13.7.4
  ↓ (micro preset = 384Mi memory limit)
  ↓ (sets: heapSize: 1024)

Might be getting something wrong as I'd be surprised if this hadn't been noticed before, so if no one else can replicate might be something specific to my setup, but this change did fix it. 

Also langfuse uses ClickHouse chart [v8.05](https://github.com/langfuse/langfuse-k8s/blob/main/charts/langfuse/Chart.yaml#L22), maybe a later Clickhouse chart will also fix but unsure, it's up to v9.3.8. Although still looks like [micro is the zookeeper default](https://github.com/bitnami/charts/blob/main/bitnami/zookeeper/values.yaml#L343)