### PR TITLE
feat: support internal ingress and redis HA/encryption settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
 | alb_scheme                 | ALB scheme                                                                                    | string       | "internet-facing"                      |    no    |
 | ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                          |    no    |
+| redis_at_rest_encryption   | At rest encryption enabled for the redis cluster                                              | bool         | false                                  |    no    |
+| redis_multi_az             | Multi availability zone enabled for the redis cluster                                         | bool         | false                                  |    no    |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_memory          | Memory allocation for ClickHouse containers                                                   | string       | "8Gi"                                  |    no    |
 | clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
+| alb_scheme                 | ALB scheme                                                                                    | string       | "internet-facing"                      |    no    |
+| ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                          |    no    |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,16 @@ This module aims to provide a production-ready, secure, and scalable deployment 
 
 ```hcl
 module "langfuse" {
-  source = "github.com/langfuse/langfuse-terraform-aws?ref=0.2.5"
+  source = "github.com/langfuse/langfuse-terraform-aws?ref=0.2.6"
 
   domain = "langfuse.example.com"
 
   # Optional use a different name for your installation
   # e.g. when using the module multiple times on the same AWS account
   name   = "langfuse"
+
+  # Optional: Configure Langfuse
+  use_encryption_key = true # Enable encryption for sensitive data stored in Langfuse
 
   # Optional: Configure the VPC
   vpc_cidr = "10.0.0.0/16"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module aims to provide a production-ready, secure, and scalable deployment 
 
 ```hcl
 module "langfuse" {
-  source = "github.com/langfuse/langfuse-terraform-aws?ref=0.2.4"
+  source = "github.com/langfuse/langfuse-terraform-aws?ref=0.2.5"
 
   domain = "langfuse.example.com"
 
@@ -40,7 +40,7 @@ module "langfuse" {
   cache_instance_count = 2
 
   # Optional: Configure Langfuse Helm chart version
-  langfuse_helm_chart_version = "1.2.8"
+  langfuse_helm_chart_version = "1.2.15"
 }
 
 provider "kubernetes" {
@@ -184,7 +184,7 @@ This module creates a complete Langfuse stack with the following components:
 | postgres_max_capacity      | Maximum ACU capacity for PostgreSQL Serverless v2                                              | number       | 2.0                                    |    no    |
 | cache_node_type            | ElastiCache node type                                                                          | string       | "cache.t4g.small"                      |    no    |
 | cache_instance_count       | Number of ElastiCache instances                                                                | number       | 1                                      |    no    |
-| langfuse_helm_chart_version | Version of the Langfuse Helm chart to deploy                                                  | string       | "1.2.8"                                |    no    |
+| langfuse_helm_chart_version | Version of the Langfuse Helm chart to deploy                                                  | string       | "1.2.15"                                |    no    |
 
 ## Outputs
 

--- a/efs.tf
+++ b/efs.tf
@@ -1,7 +1,7 @@
 # EFS File System
 resource "aws_efs_file_system" "langfuse" {
-  creation_token = "${var.name}-efs"
-  encrypted      = true
+  creation_token  = "${var.name}-efs"
+  encrypted       = true
   throughput_mode = "elastic"
 
   tags = {

--- a/examples/quickstart/quickstart.tf
+++ b/examples/quickstart/quickstart.tf
@@ -28,7 +28,7 @@ module "langfuse" {
   cache_instance_count = 2
 
   # Optional: Configure Langfuse Helm chart version
-  langfuse_helm_chart_version = "1.2.8"
+  langfuse_helm_chart_version = "1.2.15"
 }
 
 provider "kubernetes" {

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -1,5 +1,6 @@
 locals {
-  langfuse_values = <<EOT
+  inbound_cidrs_csv = join(",", var.ingress_inbound_cidrs)
+  langfuse_values   = <<EOT
 global:
   defaultStorageClass: efs
 langfuse:
@@ -80,16 +81,17 @@ s3:
   mediaUpload:
     prefix: "media/"
 EOT
-  ingress_values  = <<EOT
+  ingress_values    = <<EOT
 langfuse:
   ingress:
     enabled: true
     className: alb
     annotations:
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
+      alb.ingress.kubernetes.io/scheme: ${var.alb_scheme}
+      alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/ssl-redirect: '443'
+      alb.ingress.kubernetes.io/inbound-cidrs: ${local.inbound_cidrs_csv}
     hosts:
     - host: ${var.domain}
       paths:

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -129,6 +129,7 @@ resource "helm_release" "langfuse" {
   values = [
     local.langfuse_values,
     local.ingress_values,
+    local.encryption_values,
   ]
 
   depends_on = [

--- a/redis.tf
+++ b/redis.tf
@@ -66,6 +66,8 @@ resource "aws_elasticache_replication_group" "redis" {
   engine_version             = "7.0"
   auth_token                 = random_password.redis_password.result
   transit_encryption_enabled = true
+  at_rest_encryption_enabled = var.redis_at_rest_encryption
+  multi_az_enabled           = var.redis_multi_az
 
   log_delivery_configuration {
     destination      = aws_cloudwatch_log_group.redis.name

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,15 @@ variable "ingress_inbound_cidrs" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
+
+variable "redis_at_rest_encryption" {
+  description = "Whether at-rest encryption is enabled for the Redis cluster"
+  type        = bool
+  default     = false
+}
+
+variable "redis_multi_az" {
+  description = "Whether Multi-AZ is enabled for the Redis cluster"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,3 +127,15 @@ variable "clickhouse_keeper_memory" {
   type        = string
   default     = "2Gi"
 }
+
+variable "alb_scheme" {
+  description = "Scheme for the ALB (internal or internet-facing)"
+  type        = string
+  default     = "internet-facing"
+}
+
+variable "ingress_inbound_cidrs" {
+  description = "List of CIDR blocks allowed to access the ingress"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -82,5 +82,5 @@ variable "use_single_nat_gateway" {
 variable "langfuse_helm_chart_version" {
   description = "Version of the Langfuse Helm chart to deploy"
   type        = string
-  default     = "1.2.8"
+  default     = "1.2.15"
 }


### PR DESCRIPTION
Add module variables for a variety of customizations, in our case, for soc-2 compliance.

* alb_scheme - expose scheme from the ingress annotations so users can specify internal if an internal load balancer is desired
* ingress_inbound_cidrs - allow users to customize the generated security group attached to the ingress load balancer
* redis_at_rest_encryption - allow users to enable at rest encryption for the redis cluster
* redis_multi_az - allow users to enable multi_az on the redis cluster