### PR TITLE
feat: change use_encryption_key default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module "langfuse" {
   name   = "langfuse"
 
   # Optional: Configure Langfuse
-  use_encryption_key = true # Enable encryption for sensitive data stored in Langfuse
+  # use_encryption_key = false # Disable encryption (default is true for security)
 
   # Optional: Configure the VPC
   vpc_cidr = "10.0.0.0/16"
@@ -229,7 +229,7 @@ This module creates a complete Langfuse stack with the following components:
 | vpc_cidr                   | CIDR block for VPC                                                                             | string       | "10.0.0.0/16"                          |    no    |
 | use_single_nat_gateway     | To use a single NAT Gateway (cheaper) or one per AZ (more resilient)                           | bool         | true                                   |    no    |
 | kubernetes_version         | Kubernetes version for EKS cluster                                                             | string       | "1.32"                                 |    no    |
-| use_encryption_key         | Wheter or not to use an Encryption key for LLM API credential and integration credential store | bool         | false                                  |    no    |
+| use_encryption_key         | Wheter or not to use an Encryption key for LLM API credential and integration credential store | bool         | true                                   |    no    |
 | fargate_profile_namespaces | List of namespaces to create Fargate profiles for                                              | list(string) | ["default", "langfuse", "kube-system"] |    no    |
 | postgres_instance_count    | Number of PostgreSQL instances                                                                 | number       | 2                                      |    no    |
 | postgres_min_capacity      | Minimum ACU capacity for PostgreSQL Serverless v2                                              | number       | 0.5                                    |    no    |

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "kubernetes_version" {
 variable "use_encryption_key" {
   description = "Wheter or not to use an Encryption key for LLM API credential and integration credential store"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "postgres_instance_count" {


### PR DESCRIPTION
## Summary
- Changed the default value of `use_encryption_key` from `false` to `true`
- Updated README to show `use_encryption_key = false` as an optional override
- Aligned with [langfuse-terraform-azure module](https://github.com/langfuse/langfuse-terraform-azure/blob/dc3b27ad4c20ceada6ed6bacf89802c5e66c5fda/variables.tf#L75) which already defaults to `true`

## Motivation
Most users need to configure LLM API keys in Langfuse, which requires the `ENCRYPTION_KEY` to be set. Without this key, users encounter errors when trying to add LLM providers.

This is actual error I have encountered while setting up self host langfuse.
<img width="1891" height="965" alt="image" src="https://github.com/user-attachments/assets/fb0b6fc7-8d0e-4f09-b333-8620df7a1156" />

I have found jasyao.6 experienced the same error.
https://discord.com/channels/1111061815649124414/1152368641321480302/1387294233055985705

By enabling encryption by default:
- Reduces setup friction for new users
- Improves security by default
- Prevents common configuration errors
- Aligns with the Azure module's approach

Users can still opt-out by explicitly setting `use_encryption_key = false` if needed.