### PR TITLE
feat: allow custom PostgreSQL port configuration

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -36,7 +36,7 @@ langfuse:
     replicas: ${var.langfuse_worker_replicas}
 postgresql:
   deploy: false
-  host: ${aws_rds_cluster.postgres.endpoint}:5432
+  host: ${aws_rds_cluster.postgres.endpoint}:${aws_rds_cluster.postgres.port}
   auth:
     username: langfuse
     database: langfuse

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -4,8 +4,8 @@ resource "aws_security_group" "postgres" {
   vpc_id      = local.vpc_id
 
   ingress {
-    from_port   = 5432
-    to_port     = 5432
+    from_port   = var.postgres_port
+    to_port     = var.postgres_port
     protocol    = "tcp"
     cidr_blocks = [local.vpc_cidr_block]
   }
@@ -57,6 +57,7 @@ resource "aws_rds_cluster" "postgres" {
   backup_retention_period      = 7
   preferred_backup_window      = "03:00-04:00"
   preferred_maintenance_window = "mon:04:00-mon:05:00"
+  port                         = var.postgres_port
 
   serverlessv2_scaling_configuration {
     min_capacity = var.postgres_min_capacity

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "postgres_version" {
   default     = "15.12"
 }
 
+variable "postgres_port" {
+  description = "PostgreSQL port"
+  type        = number
+  default     = 5432
+}
+
 variable "cache_node_type" {
   description = "ElastiCache node type"
   type        = string


### PR DESCRIPTION
## Summary
- Adds a `postgres_port` variable (default `5432`) to allow overriding the PostgreSQL port
- Uses the variable in the security group ingress rules and RDS cluster resource
- References the cluster port dynamically in helm values instead of hardcoding `5432`

Useful for security hardening by running the database on a non-standard port.

## Test plan
- [ ] `terraform plan` with default port (5432) — no changes expected
- [ ] `terraform plan` with custom port — verify SG rules, RDS cluster port, and helm values reflect the new port

🤖 Generated with [Claude Code](https://claude.com/claude-code)