### PR TITLE
security: set RDS instances to not be publicly accessible

### DIFF
--- a/postgresql.tf
+++ b/postgresql.tf
@@ -79,8 +79,9 @@ resource "aws_rds_cluster_instance" "postgres" {
   identifier         = "${var.name}-postgres-${count.index + 1}"
   cluster_identifier = aws_rds_cluster.postgres.id
   instance_class     = "db.serverless"
-  engine             = aws_rds_cluster.postgres.engine
-  engine_version     = aws_rds_cluster.postgres.engine_version
+  engine              = aws_rds_cluster.postgres.engine
+  engine_version      = aws_rds_cluster.postgres.engine_version
+  publicly_accessible = false
 
   # Enable Performance Insights
   performance_insights_enabled          = true


### PR DESCRIPTION
## Summary
- Explicitly sets `publicly_accessible = false` on Aurora PostgreSQL instances
- Prevents accidental public exposure of the database, even when deployed in public subnets

## Test plan
- [ ] `terraform plan` — verify `publicly_accessible = false` appears on `aws_rds_cluster_instance`
- [ ] Existing deployments: should show no change if instances were already private by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)