### PR TITLE
feat: enhance ALB security with TLS 1.3 and protection settings

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -121,6 +121,10 @@ langfuse:
       alb.ingress.kubernetes.io/scheme: ${var.alb_scheme}
       alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/ssl-redirect: '443'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      alb.ingress.kubernetes.io/load-balancer-attributes: |
+        deletion_protection.enabled=true,
+        routing.http.drop_invalid_header_fields.enabled=true
       alb.ingress.kubernetes.io/inbound-cidrs: ${local.inbound_cidrs_csv}
     hosts:
     - host: ${var.domain}


### PR DESCRIPTION
## Summary
- Enforces TLS 1.3 minimum via `ELBSecurityPolicy-TLS13-1-2-2021-06` SSL policy
- Enables deletion protection on the ALB to prevent accidental deletion
- Drops invalid HTTP header fields to mitigate header injection attacks

## Test plan
- [ ] `terraform plan` — verify new ALB annotations appear in the ingress values
- [ ] After apply, confirm ALB uses TLS 1.3 policy and has deletion protection enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)