### PR TITLE
chore: bump Redis engine version from 7.0 to 7.1

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -63,7 +63,7 @@ resource "aws_elasticache_replication_group" "redis" {
   subnet_group_name          = aws_elasticache_subnet_group.redis.name
   security_group_ids         = [aws_security_group.redis.id]
   engine                     = "redis"
-  engine_version             = "7.0"
+  engine_version             = "7.1"
   auth_token                 = random_password.redis_password.result
   transit_encryption_enabled = true
   at_rest_encryption_enabled = var.redis_at_rest_encryption


### PR DESCRIPTION
## Summary
- Upgrades ElastiCache Redis default engine version from 7.0 to 7.1
- Picks up latest performance improvements and security patches

## Test plan
- [ ] `terraform plan` on new deployment — should use Redis 7.1
- [ ] Existing deployments: will trigger an in-place engine upgrade (verify maintenance window is acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)