### PR TITLE
feat: add support for external ClickHouse instances

### DIFF
--- a/clickhouse.tf
+++ b/clickhouse.tf
@@ -9,6 +9,11 @@ resource "random_password" "clickhouse_password" {
   min_numeric = 1
 }
 
+moved {
+  from = random_password.clickhouse_password
+  to   = random_password.clickhouse_password[0]
+}
+
 # EFS Access Points for Clickhouse instances
 resource "aws_efs_access_point" "clickhouse" {
   count          = var.clickhouse_deploy ? var.clickhouse_instance_count : 0

--- a/clickhouse.tf
+++ b/clickhouse.tf
@@ -1,6 +1,7 @@
 # Random password for ClickHouse
 # Using a alphanumeric password to avoid issues with special characters on bash entrypoint
 resource "random_password" "clickhouse_password" {
+  count       = var.clickhouse_password == "" ? 1 : 0
   length      = 64
   special     = false
   min_lower   = 1
@@ -10,8 +11,8 @@ resource "random_password" "clickhouse_password" {
 
 # EFS Access Points for Clickhouse instances
 resource "aws_efs_access_point" "clickhouse" {
-  count          = var.clickhouse_instance_count
-  file_system_id = aws_efs_file_system.langfuse.id
+  count          = var.clickhouse_deploy ? var.clickhouse_instance_count : 0
+  file_system_id = aws_efs_file_system.langfuse[0].id
 
   root_directory {
     path = "/clickhouse/${count.index}"
@@ -34,8 +35,8 @@ resource "aws_efs_access_point" "clickhouse" {
 
 # EFS Access Points for Zookeeper instances
 resource "aws_efs_access_point" "zookeeper" {
-  count          = var.clickhouse_instance_count
-  file_system_id = aws_efs_file_system.langfuse.id
+  count          = var.clickhouse_deploy ? var.clickhouse_instance_count : 0
+  file_system_id = aws_efs_file_system.langfuse[0].id
 
   root_directory {
     path = "/zookeeper/${count.index}"
@@ -58,7 +59,7 @@ resource "aws_efs_access_point" "zookeeper" {
 
 # Create the Clickhouse PVs
 resource "kubernetes_persistent_volume" "clickhouse_data" {
-  count = var.clickhouse_instance_count
+  count = var.clickhouse_deploy ? var.clickhouse_instance_count : 0
 
   metadata {
     name = "clickhouse-data-${count.index}"
@@ -71,11 +72,11 @@ resource "kubernetes_persistent_volume" "clickhouse_data" {
     volume_mode                      = "Filesystem"
     access_modes                     = ["ReadWriteOnce"]
     persistent_volume_reclaim_policy = "Retain"
-    storage_class_name               = kubernetes_storage_class.efs.metadata[0].name
+    storage_class_name               = kubernetes_storage_class.efs[0].metadata[0].name
     persistent_volume_source {
       csi {
         driver        = "efs.csi.aws.com"
-        volume_handle = "${aws_efs_file_system.langfuse.id}::${aws_efs_access_point.clickhouse[count.index].id}"
+        volume_handle = "${aws_efs_file_system.langfuse[0].id}::${aws_efs_access_point.clickhouse[count.index].id}"
       }
     }
     claim_ref {
@@ -90,7 +91,7 @@ resource "kubernetes_persistent_volume" "clickhouse_data" {
 }
 
 resource "kubernetes_persistent_volume" "clickhouse_zookeeper" {
-  count = var.clickhouse_instance_count
+  count = var.clickhouse_deploy ? var.clickhouse_instance_count : 0
 
   metadata {
     name = "clickhouse-zookeeper-${count.index}"
@@ -103,11 +104,11 @@ resource "kubernetes_persistent_volume" "clickhouse_zookeeper" {
     volume_mode                      = "Filesystem"
     access_modes                     = ["ReadWriteOnce"]
     persistent_volume_reclaim_policy = "Retain"
-    storage_class_name               = kubernetes_storage_class.efs.metadata[0].name
+    storage_class_name               = kubernetes_storage_class.efs[0].metadata[0].name
     persistent_volume_source {
       csi {
         driver        = "efs.csi.aws.com"
-        volume_handle = "${aws_efs_file_system.langfuse.id}::${aws_efs_access_point.zookeeper[count.index].id}"
+        volume_handle = "${aws_efs_file_system.langfuse[0].id}::${aws_efs_access_point.zookeeper[count.index].id}"
       }
     }
     claim_ref {

--- a/efs.tf
+++ b/efs.tf
@@ -1,5 +1,6 @@
 # EFS File System
 resource "aws_efs_file_system" "langfuse" {
+  count           = var.clickhouse_deploy ? 1 : 0
   creation_token  = "${var.name}-efs"
   encrypted       = true
   throughput_mode = "elastic"
@@ -11,14 +12,15 @@ resource "aws_efs_file_system" "langfuse" {
 
 # Mount targets in each private subnet
 resource "aws_efs_mount_target" "eks" {
-  count           = length(local.private_subnets)
-  file_system_id  = aws_efs_file_system.langfuse.id
+  count           = var.clickhouse_deploy ? length(local.private_subnets) : 0
+  file_system_id  = aws_efs_file_system.langfuse[0].id
   subnet_id       = local.private_subnets[count.index]
-  security_groups = [aws_security_group.efs.id]
+  security_groups = [aws_security_group.efs[0].id]
 }
 
 # Security group for EFS
 resource "aws_security_group" "efs" {
+  count       = var.clickhouse_deploy ? 1 : 0
   name        = "${var.name}-efs"
   description = "Security group for EFS"
   vpc_id      = local.vpc_id
@@ -45,7 +47,8 @@ resource "aws_security_group" "efs" {
 
 # EFS CSI Driver IAM Policy
 resource "aws_iam_policy" "efs" {
-  name = "${var.name}-efs"
+  count = var.clickhouse_deploy ? 1 : 0
+  name  = "${var.name}-efs"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -92,7 +95,8 @@ resource "aws_iam_policy" "efs" {
 
 # EFS CSI Driver IAM Role
 resource "aws_iam_role" "efs" {
-  name = "${var.name}-efs-csi"
+  count = var.clickhouse_deploy ? 1 : 0
+  name  = "${var.name}-efs-csi"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -114,11 +118,13 @@ resource "aws_iam_role" "efs" {
 }
 
 resource "aws_iam_role_policy_attachment" "efs" {
-  policy_arn = aws_iam_policy.efs.arn
-  role       = aws_iam_role.efs.name
+  count      = var.clickhouse_deploy ? 1 : 0
+  policy_arn = aws_iam_policy.efs[0].arn
+  role       = aws_iam_role.efs[0].name
 }
 
 resource "kubernetes_storage_class" "efs" {
+  count = var.clickhouse_deploy ? 1 : 0
   metadata {
     name = "efs"
   }

--- a/efs.tf
+++ b/efs.tf
@@ -130,3 +130,36 @@ resource "kubernetes_storage_class" "efs" {
   }
   storage_provisioner = "efs.csi.aws.com"
 }
+
+# Preserve existing state when adding `count` to previously-singleton resources
+# so that enabling `clickhouse_deploy = true` (the default) on an existing
+# deployment doesn't destroy and recreate the EFS file system, IAM, etc.
+moved {
+  from = aws_efs_file_system.langfuse
+  to   = aws_efs_file_system.langfuse[0]
+}
+
+moved {
+  from = aws_security_group.efs
+  to   = aws_security_group.efs[0]
+}
+
+moved {
+  from = aws_iam_policy.efs
+  to   = aws_iam_policy.efs[0]
+}
+
+moved {
+  from = aws_iam_role.efs
+  to   = aws_iam_role.efs[0]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.efs
+  to   = aws_iam_role_policy_attachment.efs[0]
+}
+
+moved {
+  from = kubernetes_storage_class.efs
+  to   = kubernetes_storage_class.efs[0]
+}

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -1,8 +1,13 @@
 locals {
   inbound_cidrs_csv = join(",", var.ingress_inbound_cidrs)
-  langfuse_values   = <<EOT
+
+  # Only set EFS as default storage class when deploying bundled ClickHouse
+  clickhouse_storage_values = !var.clickhouse_deploy ? "" : <<EOT
 global:
   defaultStorageClass: efs
+EOT
+
+  langfuse_values = <<EOT
 langfuse:
   salt:
     secretKeyRef:
@@ -43,6 +48,29 @@ postgresql:
     existingSecret: langfuse
     secretKeys:
       userPasswordKey: postgres-password
+redis:
+  deploy: false
+  host: ${aws_elasticache_replication_group.redis.primary_endpoint_address}
+  auth:
+    existingSecret: langfuse
+    existingSecretPasswordKey: redis-password
+  tls:
+    enabled: true
+s3:
+  deploy: false
+  bucket: ${aws_s3_bucket.langfuse.id}
+  region: ${data.aws_region.current.id}
+  forcePathStyle: false
+  eventUpload:
+    prefix: "events/"
+  batchExport:
+    prefix: "exports/"
+  mediaUpload:
+    prefix: "media/"
+EOT
+
+  # Bundled ClickHouse deployed via the Helm chart
+  clickhouse_bundled_values = <<EOT
 clickhouse:
   auth:
     existingSecret: langfuse
@@ -66,26 +94,26 @@ clickhouse:
       requests:
         cpu: "${var.clickhouse_keeper_cpu}"
         memory: "${var.clickhouse_keeper_memory}"
-redis:
-  deploy: false
-  host: ${aws_elasticache_replication_group.redis.primary_endpoint_address}
-  auth:
-    existingSecret: langfuse
-    existingSecretPasswordKey: redis-password
-  tls:
-    enabled: true
-s3:
-  deploy: false
-  bucket: ${aws_s3_bucket.langfuse.id}
-  region: ${data.aws_region.current.id}
-  forcePathStyle: false
-  eventUpload:
-    prefix: "events/"
-  batchExport:
-    prefix: "exports/"
-  mediaUpload:
-    prefix: "media/"
 EOT
+
+  # External ClickHouse instance (e.g. ClickHouse Cloud)
+  clickhouse_external_values = <<EOT
+clickhouse:
+  deploy: false
+  host: ${var.clickhouse_host}
+  httpPort: ${var.clickhouse_http_port}
+  nativePort: ${var.clickhouse_native_port}
+  auth:
+    username: ${var.clickhouse_user}
+    database: ${var.clickhouse_database}
+    existingSecret: langfuse
+    existingSecretKey: clickhouse-password
+  migration:
+    ssl: ${var.clickhouse_ssl}
+  clusterEnabled: ${var.clickhouse_cluster_enabled}
+EOT
+
+  clickhouse_values = var.clickhouse_deploy ? local.clickhouse_bundled_values : local.clickhouse_external_values
 
   additional_env_values = length(var.additional_env) == 0 ? "" : <<EOT
 langfuse:
@@ -144,7 +172,7 @@ EOT
   # <asynchronous_insert_log remove="1"/>
   # <query_metric_log remove="1"/>
   # <error_log remove="1"/>
-  clickhouse_overwrite_values = var.enable_clickhouse_log_tables ? "" : <<EOT
+  clickhouse_overwrite_values = !var.clickhouse_deploy || var.enable_clickhouse_log_tables ? "" : <<EOT
 clickhouse:
   extraOverrides: |
       <clickhouse>
@@ -191,7 +219,7 @@ resource "kubernetes_secret" "langfuse" {
     "postgres-password"   = random_password.postgres_password.result
     "salt"                = random_bytes.salt.base64
     "nextauth-secret"     = random_bytes.nextauth_secret.base64
-    "clickhouse-password" = random_password.clickhouse_password.result
+    "clickhouse-password" = var.clickhouse_password != "" ? var.clickhouse_password : random_password.clickhouse_password[0].result
     "encryption_key"      = var.use_encryption_key ? random_bytes.encryption_key[0].hex : ""
   }
 }
@@ -204,7 +232,9 @@ resource "helm_release" "langfuse" {
   namespace  = kubernetes_namespace.langfuse.metadata[0].name
 
   values = compact([
+    local.clickhouse_storage_values,
     local.langfuse_values,
+    local.clickhouse_values,
     local.ingress_values,
     local.encryption_values,
     local.additional_env_values,
@@ -222,4 +252,3 @@ resource "helm_release" "langfuse" {
     helm_release.aws_load_balancer_controller
   ]
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -254,3 +254,59 @@ variable "additional_env" {
     error_message = "Each environment variable must have either 'value' or 'valueFrom' specified, but not both."
   }
 }
+
+# External ClickHouse configuration
+variable "clickhouse_deploy" {
+  description = "Deploy ClickHouse via Helm chart. Set to false to use an external ClickHouse instance."
+  type        = bool
+  default     = true
+}
+
+variable "clickhouse_host" {
+  description = "Hostname of external ClickHouse instance (required when clickhouse_deploy = false)"
+  type        = string
+  default     = ""
+}
+
+variable "clickhouse_http_port" {
+  description = "HTTP port for external ClickHouse (8123 for non-TLS, 8443 for TLS)"
+  type        = number
+  default     = 8443
+}
+
+variable "clickhouse_native_port" {
+  description = "Native/TCP port for external ClickHouse (9000 for non-TLS, 9440 for TLS)"
+  type        = number
+  default     = 9440
+}
+
+variable "clickhouse_database" {
+  description = "ClickHouse database name"
+  type        = string
+  default     = "default"
+}
+
+variable "clickhouse_user" {
+  description = "ClickHouse username"
+  type        = string
+  default     = "default"
+}
+
+variable "clickhouse_password" {
+  description = "ClickHouse password for external instance. If empty, a random password is generated (for bundled ClickHouse)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "clickhouse_ssl" {
+  description = "Use SSL for ClickHouse migration connection (required for ClickHouse Cloud)"
+  type        = bool
+  default     = true
+}
+
+variable "clickhouse_cluster_enabled" {
+  description = "Enable ON CLUSTER DDL commands. Set to false for ClickHouse Cloud."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

- Add `clickhouse_deploy` variable (default `true`) to toggle between bundled and external ClickHouse
- When `clickhouse_deploy = false`, skip all EFS and ClickHouse PV/access point resources, and configure the Helm chart to connect to an external ClickHouse instance
- Add variables for external ClickHouse configuration: `clickhouse_host`, `clickhouse_http_port`, `clickhouse_native_port`, `clickhouse_database`, `clickhouse_user`, `clickhouse_password`, `clickhouse_ssl`, `clickhouse_cluster_enabled`
- Gate all EFS resources (file system, mount targets, security group, IAM policy/role, storage class) behind `clickhouse_deploy`
- Zero breaking changes: existing deployments with default `clickhouse_deploy = true` continue to work identically

## Motivation

The bundled ClickHouse deployment uses EFS for persistent storage, which incurs ~$400/month due to ClickHouse's write-heavy I/O patterns. Using an external ClickHouse instance (e.g. ClickHouse Cloud) eliminates the need for EFS entirely, significantly reducing costs while improving ClickHouse performance.

## Test plan

- [x] `terraform validate` passes
- [x] `terraform plan` with `clickhouse_deploy = true` (default) shows no resource additions or deletions — only cosmetic Helm values restructuring and automatic `[0]` index moves
- [x] `terraform plan` with `clickhouse_deploy = false` + external ClickHouse vars shows EFS/ClickHouse resources removed and Helm values updated
- [x] Successfully applied with `clickhouse_deploy = true` on a live deployment confirming backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)