### PR TITLE
feat: upgrade ALB SSL policy to TLS 1.3 with post-quantum support

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -121,6 +121,7 @@ langfuse:
       alb.ingress.kubernetes.io/scheme: ${var.alb_scheme}
       alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/ssl-redirect: '443'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-3-PQ-2025-09
       alb.ingress.kubernetes.io/inbound-cidrs: ${local.inbound_cidrs_csv}
     hosts:
     - host: ${var.domain}


### PR DESCRIPTION
## Summary
- Adds `alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-3-PQ-2025-09` to the ALB ingress annotations
- Enforces TLS 1.3 only with post-quantum key exchange support
- Addresses the "Load Balancers should use the latest security policy" security finding

## Test plan
- [ ] Verify `terraform plan` shows the expected annotation change
- [ ] Confirm ALB listener updates to the new SSL policy after apply
- [ ] Validate TLS 1.3 connectivity with `openssl s_client -connect <domain>:443`
- [ ] Confirm TLS 1.2 clients are correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)