### PR TITLE
External DNS Setup + Unique IAM names + Bug Fixes

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -45,7 +45,7 @@ resource "aws_security_group" "efs" {
 
 # EFS CSI Driver IAM Policy
 resource "aws_iam_policy" "efs" {
-  name = "${var.name}-efs"
+  name_prefix = "${var.name}-efs-"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -92,7 +92,7 @@ resource "aws_iam_policy" "efs" {
 
 # EFS CSI Driver IAM Role
 resource "aws_iam_role" "efs" {
-  name = "${var.name}-efs-csi"
+  name_prefix = "${var.name}-efs-csi-"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/eks.tf
+++ b/eks.tf
@@ -45,7 +45,7 @@ data "tls_certificate" "eks" {
 
 # Fargate Profile Role
 resource "aws_iam_role" "fargate" {
-  name = "${var.name}-fargate"
+  name_prefix = "${var.name}-fargate-"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -117,7 +117,7 @@ resource "aws_security_group_rule" "eks_vpc" {
 }
 
 resource "aws_iam_role" "eks" {
-  name = "${var.name}-eks"
+  name_prefix = "${var.name}-eks-"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/eks.tf
+++ b/eks.tf
@@ -150,4 +150,19 @@ resource "aws_iam_role_policy_attachment" "eks_service_policy" {
 resource "aws_cloudwatch_log_group" "eks" {
   name              = "/aws/eks/${var.name}/cluster"
   retention_in_days = 30
-} 
+}
+
+# EKS deploys CoreDNS expecting EC2 nodes. On Fargate-only clusters the pods
+# stay Pending (and all in-cluster DNS fails) until this annotation is present.
+resource "kubernetes_annotations" "coredns_fargate" {
+  api_version = "apps/v1"
+  kind        = "Deployment"
+  metadata {
+    name      = "coredns"
+    namespace = "kube-system"
+  }
+  template_annotations = {
+    "eks.amazonaws.com/compute-type" = "fargate"
+  }
+  depends_on = [aws_eks_fargate_profile.namespaces]
+}

--- a/ingress.tf
+++ b/ingress.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller_assume_role_policy"
 
 resource "aws_iam_role" "aws_load_balancer_controller" {
   assume_role_policy = data.aws_iam_policy_document.aws_load_balancer_controller_assume_role_policy.json
-  name               = "aws-load-balancer-controller"
+  name_prefix               = "langfuse-aws-load-balancer-controller-"
 
   tags = {
     Name = "${local.tag_name} ALB"
@@ -28,8 +28,8 @@ resource "aws_iam_role" "aws_load_balancer_controller" {
 }
 
 resource "aws_iam_policy" "aws_load_balancer_controller" {
-  name        = "AWSLoadBalancerControllerIAMPolicy"
-  description = "IAM policy for AWS Load Balancer Controller"
+  name_prefix = "langfuse-aws-load-balancer-controller-iam-policy-"
+  description = "IAM policy for Langfuse Load Balancer Controller"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -122,6 +122,7 @@ langfuse:
       alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/ssl-redirect: '443'
       alb.ingress.kubernetes.io/inbound-cidrs: ${local.inbound_cidrs_csv}
+      alb.ingress.kubernetes.io/certificate-arn: ${local.certificate_arn}
     hosts:
     - host: ${var.domain}
       paths:

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -198,11 +198,9 @@ resource "kubernetes_secret" "langfuse" {
 }
 
 resource "helm_release" "langfuse" {
-  name       = "langfuse"
-  repository = "https://langfuse.github.io/langfuse-k8s"
-  version    = var.langfuse_helm_chart_version
-  chart      = "langfuse"
-  namespace  = kubernetes_namespace.langfuse.metadata[0].name
+  name      = "langfuse"
+  chart     = "https://github.com/langfuse/langfuse-k8s/releases/download/langfuse-${var.langfuse_helm_chart_version}/langfuse-${var.langfuse_helm_chart_version}.tgz"
+  namespace = kubernetes_namespace.langfuse.metadata[0].name
 
   values = compact([
     local.langfuse_values,

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -184,7 +184,7 @@ resource "random_bytes" "encryption_key" {
 resource "kubernetes_secret" "langfuse" {
   metadata {
     name      = "langfuse"
-    namespace = "langfuse"
+    namespace = kubernetes_namespace.langfuse.metadata[0].name
   }
 
   data = {

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -202,6 +202,11 @@ resource "helm_release" "langfuse" {
   chart     = "https://github.com/langfuse/langfuse-k8s/releases/download/langfuse-${var.langfuse_helm_chart_version}/langfuse-${var.langfuse_helm_chart_version}.tgz"
   namespace = kubernetes_namespace.langfuse.metadata[0].name
 
+  # Fargate + EFS cold-start overhead means the default 300s is not enough.
+  # ClickHouse tables need ~60s to initialize after ZooKeeper becomes ready,
+  # and the web pod may crash-restart once before ClickHouse is fully ready.
+  timeout = var.helm_release_timeout
+
   values = compact([
     local.langfuse_values,
     local.ingress_values,

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  tag_name = lower(var.name) == "langfuse" ? "Langfuse" : "Langfuse ${var.name}"
+  tag_name        = lower(var.name) == "langfuse" ? "Langfuse" : "Langfuse ${var.name}"
+  certificate_arn = var.certificate_arn != null ? var.certificate_arn : aws_acm_certificate_validation.cert[0].certificate_arn
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
   tag_name        = lower(var.name) == "langfuse" ? "Langfuse" : "Langfuse ${var.name}"
-  certificate_arn = var.certificate_arn != null ? var.certificate_arn : aws_acm_certificate_validation.cert[0].certificate_arn
+  certificate_arn = var.skip_dns_setup ? var.certificate_arn : aws_acm_certificate_validation.cert[0].certificate_arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,8 +21,18 @@ output "cluster_token" {
 }
 
 output "route53_nameservers" {
-  description = "Nameserver for the Route53 zone"
-  value       = aws_route53_zone.zone.name_servers
+  description = "Nameservers for the Route53 zone (null when skip_dns_setup is true)"
+  value       = var.skip_dns_setup ? null : aws_route53_zone.zone[0].name_servers
+}
+
+output "load_balancer_dns_name" {
+  description = "DNS name of the ALB created for Langfuse"
+  value       = data.aws_lb.ingress.dns_name
+}
+
+output "load_balancer_zone_id" {
+  description = "Hosted zone ID of the ALB (for use in Route53 alias records)"
+  value       = data.aws_lb.ingress.zone_id
 }
 
 output "private_subnet_ids" {

--- a/s3.tf
+++ b/s3.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "langfuse" {
 
 # Create IRSA role for Langfuse service account
 resource "aws_iam_role" "langfuse_irsa" {
-  name = "langfuse"
+  name_prefix = "langfuse-"
   path = "/kubernetes/"
 
   assume_role_policy = jsonencode({
@@ -84,7 +84,7 @@ resource "aws_iam_role" "langfuse_irsa" {
 
 # S3 access policy for the IRSA role
 resource "aws_iam_role_policy" "langfuse_s3_access" {
-  name = "s3-access"
+  name_prefix = "langfuse-s3-access-"
   role = aws_iam_role.langfuse_irsa.id
 
   policy = jsonencode({

--- a/s3.tf
+++ b/s3.tf
@@ -107,5 +107,36 @@ resource "aws_iam_role_policy" "langfuse_s3_access" {
   })
 }
 
+# Bedrock access policy for the IRSA role
+resource "aws_iam_role_policy" "langfuse_bedrock_access" {
+  name_prefix = "langfuse-bedrock-access-"
+  role        = aws_iam_role.langfuse_irsa.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream"
+        ]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/*",
+          "arn:aws:bedrock:*:*:inference-profile/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "aws-marketplace:ViewSubscriptions",
+          "aws-marketplace:Subscribe"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 # Get current AWS account ID
 data "aws_caller_identity" "current" {}

--- a/tls-certificate.tf
+++ b/tls-certificate.tf
@@ -1,5 +1,6 @@
-# ACM Certificate for the domain
+# ACM Certificate for the domain (skipped when certificate_arn is provided)
 resource "aws_acm_certificate" "cert" {
+  count             = var.certificate_arn == null ? 1 : 0
   domain_name       = var.domain
   validation_method = "DNS"
 
@@ -21,15 +22,15 @@ resource "aws_route53_zone" "zone" {
   }
 }
 
-# Create DNS records for certificate validation
+# Create DNS records for certificate validation (skipped when certificate_arn is provided)
 resource "aws_route53_record" "cert_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+  for_each = var.certificate_arn == null ? {
+    for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-  }
+  } : {}
 
   allow_overwrite = true
   name            = each.value.name
@@ -39,9 +40,10 @@ resource "aws_route53_record" "cert_validation" {
   zone_id         = aws_route53_zone.zone.zone_id
 }
 
-# Certificate validation
+# Certificate validation (skipped when certificate_arn is provided)
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = aws_acm_certificate.cert.arn
+  count                   = var.certificate_arn == null ? 1 : 0
+  certificate_arn         = aws_acm_certificate.cert[0].arn
   validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }
 

--- a/tls-certificate.tf
+++ b/tls-certificate.tf
@@ -1,6 +1,6 @@
-# ACM Certificate for the domain (skipped when certificate_arn is provided)
+# ACM Certificate for the domain (skipped when skip_dns_setup is true)
 resource "aws_acm_certificate" "cert" {
-  count             = var.certificate_arn == null ? 1 : 0
+  count             = var.skip_dns_setup ? 0 : 1
   domain_name       = var.domain
   validation_method = "DNS"
 
@@ -13,36 +13,37 @@ resource "aws_acm_certificate" "cert" {
   }
 }
 
-# Create Route53 zone for the domain
+# Create Route53 zone for the domain (skipped when skip_dns_setup is true)
 resource "aws_route53_zone" "zone" {
-  name = var.domain
+  count = var.skip_dns_setup ? 0 : 1
+  name  = var.domain
 
   tags = {
     Name = local.tag_name
   }
 }
 
-# Create DNS records for certificate validation (skipped when certificate_arn is provided)
+# Create DNS records for certificate validation (skipped when skip_dns_setup is true)
 resource "aws_route53_record" "cert_validation" {
-  for_each = var.certificate_arn == null ? {
+  for_each = var.skip_dns_setup ? {} : {
     for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-  } : {}
+  }
 
   allow_overwrite = true
   name            = each.value.name
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = aws_route53_zone.zone.zone_id
+  zone_id         = aws_route53_zone.zone[0].zone_id
 }
 
-# Certificate validation (skipped when certificate_arn is provided)
+# Certificate validation (skipped when skip_dns_setup is true)
 resource "aws_acm_certificate_validation" "cert" {
-  count                   = var.certificate_arn == null ? 1 : 0
+  count                   = var.skip_dns_setup ? 0 : 1
   certificate_arn         = aws_acm_certificate.cert[0].arn
   validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }
@@ -61,9 +62,10 @@ data "aws_lb" "ingress" {
   ]
 }
 
-# Create Route53 record for the ALB
+# Create Route53 record for the ALB (skipped when skip_dns_setup is true)
 resource "aws_route53_record" "langfuse" {
-  zone_id = aws_route53_zone.zone.zone_id
+  count   = var.skip_dns_setup ? 0 : 1
+  zone_id = aws_route53_zone.zone[0].zone_id
   name    = var.domain
   type    = "A"
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "private_route_table_ids" {
 variable "kubernetes_version" {
   description = "Kubernetes version to use for the EKS cluster"
   type        = string
-  default     = "1.32"
+  default     = "1.35"
 }
 
 variable "use_encryption_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,12 @@ variable "langfuse_helm_chart_version" {
   default     = "1.5.29"
 }
 
+variable "helm_release_timeout" {
+  description = "Seconds to wait for the Langfuse Helm release to become ready. Fargate + EFS cold starts and the 60s ClickHouse ZooKeeper initialization cycle require more time than Helm's default 300s."
+  type        = number
+  default     = 900
+}
+
 # Resource configuration variables
 variable "langfuse_cpu" {
   description = "CPU allocation for Langfuse containers"

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "postgres_max_capacity" {
 variable "postgres_version" {
   description = "PostgreSQL engine version to use"
   type        = string
-  default     = "15.12"
+  default     = "15.15"
 }
 
 variable "cache_node_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,14 +9,25 @@ variable "domain" {
   type        = string
 }
 
+variable "skip_dns_setup" {
+  description = "When true, skips Route53 zone creation, ACM certificate creation, DNS validation records, and the Route53 alias record for the ALB. Use this when DNS and certificate management are handled externally. certificate_arn must be provided alongside this flag. The load_balancer_dns_name and load_balancer_zone_id outputs can then be used to configure DNS records outside this module."
+  type        = bool
+  default     = false
+}
+
 variable "certificate_arn" {
-  description = "ARN of an existing, validated ACM certificate to use. If not provided, a new certificate will be created and validated via Route53."
+  description = "ARN of an existing, externally managed ACM certificate. Required when skip_dns_setup is true."
   type        = string
   default     = null
 
   validation {
     condition     = var.certificate_arn == null || can(regex("^arn:aws[^:]*:acm:", var.certificate_arn))
     error_message = "certificate_arn must be a valid ACM certificate ARN."
+  }
+
+  validation {
+    condition     = !var.skip_dns_setup || var.certificate_arn != null
+    error_message = "certificate_arn must be provided when skip_dns_setup is true."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,17 @@ variable "domain" {
   type        = string
 }
 
+variable "certificate_arn" {
+  description = "ARN of an existing, validated ACM certificate to use. If not provided, a new certificate will be created and validated via Route53."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.certificate_arn == null || can(regex("^arn:aws[^:]*:acm:", var.certificate_arn))
+    error_message = "certificate_arn must be a valid ACM certificate ARN."
+  }
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for VPC"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,7 @@ variable "use_single_nat_gateway" {
 variable "langfuse_helm_chart_version" {
   description = "Version of the Langfuse Helm chart to deploy"
   type        = string
-  default     = "1.5.14"
+  default     = "1.5.29"
 }
 
 # Resource configuration variables


### PR DESCRIPTION
When attempting to deploy langfuse, we encountered a few issues. This PR fixes some of these issues. The changes made are:

- Ability to skip dns setup. The current DNS setup assumes AWS is your registrar. We use Cloudflare so the current setup wouldn't work for us so this PR adds the ability to skip the DNS setup and exposes the k8s lb needed to setup DNS externally. 
- Unique IAM names. Currently the IAM resources uses just the `name` property. This means that if you wanted to have two langfuse deployments in the same AWS account (e.g. with a mult-regional setup), you'd end up getting IAM role name clashes. This PR changes it so that the IAM resources now use name_prefix to avoid name clashes. [THIS IS A BREAKING CHANGE] because it requires some resources to be recreated so should only be released as part of a major release.  
- Adds kubernetes_annotations needed for CoreDNS.