### PR TITLE
feat(terraform): add code-based eval executors (LFE-9943)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ module "langfuse" {
   # Optional: Activate additional log tables in ClickHouse. Will increase EFS costs, but may aid in debugging.
   enable_clickhouse_log_tables = false  # Set to true to have additional logs.
 
+  # Optional: Enable code-based eval execution via tenant-isolated AWS Lambda executors.
+  enable_code_based_eval_executors = true
+
   # Optional: Add additional environment variables
   additional_env = [
     # Direct value
@@ -211,6 +214,10 @@ The default values are based on the recommendations from the [Langfuse K8s docum
 
 These defaults provide a good starting point for production workloads, but you can adjust them based on your specific requirements by setting the corresponding variables in your Terraform configuration.
 
+### Code-Based Evals
+
+Set `enable_code_based_eval_executors = true` to create isolated Python and Node.js Lambda executors for code-based evals. The code-based eval executors rely on [AWS Lambda tenant isolation](https://docs.aws.amazon.com/lambda/latest/dg/tenant-isolation.html), which keeps execution environments isolated per tenant when invoking shared Lambda functions. The module creates a dedicated no-internet VPC for the executors, grants the Langfuse service account permission to invoke them, configures the Langfuse Helm release to use the AWS Lambda dispatcher, and enables the worker queue consumer for code eval execution.
+
 ### Customizing Resources
 
 You can override any of the resource configurations by setting the appropriate variables.
@@ -255,7 +262,8 @@ This module creates a complete Langfuse stack with the following components:
 
 | Name       | Version |
 |------------|---------|
-| aws        | >= 5.0  |
+| aws        | >= 6.30 |
+| archive    | >= 2.8  |
 | kubernetes | >= 2.10 |
 | helm       | >= 2.5  |
 | random     | >= 3.0  |
@@ -314,6 +322,12 @@ This module creates a complete Langfuse stack with the following components:
 | ingress_inbound_cidrs        | Allowed CIDR blocks for ingress alb                                                                              | list(string) | ["0.0.0.0/0"]                          |    no    |
 | redis_at_rest_encryption     | At rest encryption enabled for the redis cluster                                                                 | bool         | false                                  |    no    |
 | redis_multi_az               | Multi availability zone enabled for the redis cluster                                                            | bool         | false                                  |    no    |
+| enable_code_based_eval_executors | Create tenant-isolated Lambda executors for code-based evals                                                  | bool         | false                                  |    no    |
+| vpc_cidr_block_code_based_evals  | CIDR block for the dedicated isolated code-based eval executor VPC                                           | string       | "10.1.0.0/24"                         |    no    |
+| code_based_eval_executor_lambda_settings | Per-runtime resource settings for code-based eval executor Lambdas                                   | object       | see variables.tf                       |    no    |
+| code_eval_local_timeout_ms | Local timeout in milliseconds for code eval execution requests                                                       | number       | 2000                                   |    no    |
+| code_eval_execution_queue_shard_count | Shard count for the code eval execution queue                                                            | number       | 1                                      |    no    |
+| worker_code_eval_execution_queue_processing_concurrency | Code eval execution queue processing concurrency for Langfuse worker pods                | string       | "5"                                    |    no    |
 
 ## Outputs
 
@@ -328,6 +342,7 @@ This module creates a complete Langfuse stack with the following components:
 | bucket_name            | S3 bucket name for Langfuse      |
 | bucket_id              | S3 bucket ID for Langfuse        |
 | route53_nameservers    | Route53 zone nameservers         |
+| code_based_eval_executor_lambda_function_names | Code-based eval executor Lambda function names by runtime |
 
 ## Support
 

--- a/code-eval-runners/node/code-based-eval-handler.mjs
+++ b/code-eval-runners/node/code-based-eval-handler.mjs
@@ -1,0 +1,71 @@
+import { stripTypeScriptTypes } from "node:module";
+
+// `stripTypeScriptTypes` is loaded lazily; call it once during initialization.
+stripTypeScriptTypes("");
+
+export async function handler(event) {
+  let source;
+  try {
+    source = stripTypeScriptTypes(event.code.source, { mode: "strip" });
+  } catch (error) {
+    return runnerError(
+      "INVALID_SOURCE",
+      `Failed to strip TypeScript syntax: ${formatError(error)}`,
+    );
+  }
+
+  let evaluate;
+  try {
+    evaluate = Function(
+      `${source}
+
+if (typeof evaluate !== "function") {
+  throw new Error("Evaluator source must define evaluate(ctx)");
+}
+
+return evaluate;`,
+    )();
+  } catch (error) {
+    return runnerError(
+      "INVALID_SOURCE",
+      `Failed to prepare evaluator source: ${formatError(error)}`,
+    );
+  }
+
+  let result;
+  try {
+    result = await evaluate(event.payload);
+  } catch (error) {
+    return runnerError("USER_CODE_ERROR", formatError(error));
+  }
+
+  return normalizeResult(result);
+}
+
+function normalizeResult(result) {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !Array.isArray(result.scores)
+  ) {
+    return runnerError(
+      "INVALID_RESULT",
+      "Evaluator must return an object shaped like { scores: [...] }",
+    );
+  }
+
+  return result;
+}
+
+function runnerError(code, message) {
+  return {
+    error: {
+      code,
+      message,
+    },
+  };
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/code-eval-runners/python/code_based_eval_handler.py
+++ b/code-eval-runners/python/code_based_eval_handler.py
@@ -1,0 +1,147 @@
+import asyncio
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ObservationContext:
+    input: Any = None
+    output: Any = None
+    metadata: Any = None
+
+
+@dataclass
+class ExperimentContext:
+    item_expected_output: Any = None
+    item_metadata: Any = None
+
+
+@dataclass
+class EvaluationContext:
+    observation: ObservationContext
+    experiment: ExperimentContext | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]):
+        observation = payload.get("observation") or {}
+        experiment = payload.get("experiment")
+        return cls(
+            observation=ObservationContext(
+                input=observation.get("input"),
+                output=observation.get("output"),
+                metadata=observation.get("metadata"),
+            ),
+            experiment=ExperimentContext(
+                item_expected_output=experiment.get("itemExpectedOutput"),
+                item_metadata=experiment.get("itemMetadata"),
+            )
+            if isinstance(experiment, dict)
+            else None,
+        )
+
+
+# Public dataclasses exposed to user evaluator code. Field names are Pythonic
+# (snake_case); they are translated to the camelCase wire format (`dataType`,
+# `configId`) by `to_jsonable` so users can return an `EvaluationResult`
+# directly without manual key mangling.
+@dataclass
+class Score:
+    value: int | float | str | bool
+    name: str
+    data_type: str | None = None
+    comment: str | None = None
+    config_id: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass
+class EvaluationResult:
+    scores: list[Score] = field(default_factory=list)
+
+
+# Mapping from dataclass snake_case field names to the camelCase keys expected
+# by the dispatcher wire schema. Kept as an explicit allowlist so that user
+# metadata payloads (which may legitimately contain snake_case keys) are never
+# rewritten; only dataclass field names are translated.
+_DATACLASS_FIELD_NAME_OVERRIDES: dict[str, str] = {
+    "data_type": "dataType",
+    "config_id": "configId",
+}
+
+
+def handler(event, context):
+    namespace = {
+        "EvaluationContext": EvaluationContext,
+        "EvaluationResult": EvaluationResult,
+        "Score": Score,
+    }
+
+    try:
+        exec(event["code"]["source"], namespace)
+    except Exception as error:
+        return runner_error(
+            "INVALID_SOURCE", f"Failed to load evaluator source: {error}"
+        )
+
+    evaluate = namespace.get("evaluate")
+    if not callable(evaluate):
+        return runner_error(
+            "INVALID_SOURCE", "Evaluator source must define an evaluate(ctx) function"
+        )
+
+    try:
+        result = evaluate(EvaluationContext.from_payload(event.get("payload", {})))
+        if asyncio.iscoroutine(result):
+            result = asyncio.run(result)
+    except Exception as error:
+        return runner_error("USER_CODE_ERROR", str(error))
+
+    return normalize_result(result)
+
+
+def normalize_result(result):
+    normalized = to_jsonable(result)
+
+    if not isinstance(normalized, dict) or not isinstance(
+        normalized.get("scores"), list
+    ):
+        return runner_error(
+            "INVALID_RESULT",
+            "Evaluator must return an object shaped like { scores: [...] }",
+        )
+
+    return normalized
+
+
+def to_jsonable(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        # Translate snake_case dataclass field names to the camelCase wire
+        # format and drop None-valued optional fields so that the result
+        # matches the union variants in the TypeScript schema (e.g. the
+        # `dataType: undefined` variant).
+        result = {}
+        for f in dataclasses.fields(value):
+            raw = getattr(value, f.name)
+            if raw is None:
+                continue
+            key = _DATACLASS_FIELD_NAME_OVERRIDES.get(f.name, f.name)
+            result[key] = to_jsonable(raw)
+        return result
+
+    if isinstance(value, list):
+        return [to_jsonable(item) for item in value]
+
+    if isinstance(value, dict):
+        return {key: to_jsonable(item) for key, item in value.items()}
+
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return str(value)
+
+
+def runner_error(code: str, message: str):
+    return {"error": {"code": code, "message": message}}

--- a/code_based_eval_executor.tf
+++ b/code_based_eval_executor.tf
@@ -1,0 +1,240 @@
+locals {
+  code_based_eval_executor_lambda_configs = {
+    python = {
+      function_name = "${var.name}-code-based-eval-executor-python"
+      runtime       = "python3.14"
+      handler       = "index.handler"
+      filename      = "index.py"
+      source_path   = "${path.module}/code-eval-runners/python/code_based_eval_handler.py"
+    }
+    node = {
+      function_name = "${var.name}-code-based-eval-executor-node"
+      runtime       = "nodejs24.x"
+      handler       = "index.handler"
+      filename      = "index.mjs"
+      source_path   = "${path.module}/code-eval-runners/node/code-based-eval-handler.mjs"
+    }
+  }
+
+  code_based_eval_executor_lambda_names = {
+    for runtime, config in local.code_based_eval_executor_lambda_configs : runtime => config.function_name
+  }
+}
+
+module "code_based_eval_executor_vpc" {
+  count = var.enable_code_based_eval_executors ? 1 : 0
+
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "${var.name}-vpc-code-based-eval"
+  cidr = var.vpc_cidr_block_code_based_evals
+
+  azs             = local.azs
+  private_subnets = [for k, v in local.azs : cidrsubnet(var.vpc_cidr_block_code_based_evals, 2, k)]
+
+  create_igw         = false
+  enable_nat_gateway = false
+
+  enable_flow_log                                 = true
+  create_flow_log_cloudwatch_iam_role             = true
+  create_flow_log_cloudwatch_log_group            = true
+  flow_log_cloudwatch_log_group_name_prefix       = "${var.name}-code-based-eval-"
+  flow_log_cloudwatch_log_group_retention_in_days = 14
+  flow_log_cloudwatch_log_group_class             = "INFREQUENT_ACCESS"
+
+  tags = {
+    Name = "${local.tag_name} Code-Based Eval"
+  }
+}
+
+data "archive_file" "code_based_eval_executor" {
+  for_each = var.enable_code_based_eval_executors ? local.code_based_eval_executor_lambda_configs : {}
+
+  type        = "zip"
+  output_path = "${path.module}/.terraform/code_based_eval_executor_${each.key}.zip"
+
+  source {
+    content  = file(each.value.source_path)
+    filename = each.value.filename
+  }
+}
+
+resource "aws_security_group" "code_based_eval_executor_lambda" {
+  count = var.enable_code_based_eval_executors ? 1 : 0
+
+  name        = "${var.name}-code-based-eval-executor-lambda"
+  description = "No-ingress/no-egress security group for code-based eval executor Lambdas"
+  vpc_id      = module.code_based_eval_executor_vpc[0].vpc_id
+
+  # Defense-in-depth with the isolated route table: deny all Lambda ENI egress,
+  # including VPC-local destinations.
+  ingress = []
+  egress  = []
+
+  tags = {
+    Name = "${local.tag_name} Code-Based Eval Executor Lambda"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "code_based_eval_executor" {
+  for_each = var.enable_code_based_eval_executors ? local.code_based_eval_executor_lambda_names : {}
+
+  name              = "/aws/lambda/${each.value}"
+  retention_in_days = 30
+}
+
+resource "aws_iam_role" "code_based_eval_executor_lambda" {
+  count = var.enable_code_based_eval_executors ? 1 : 0
+
+  name = "${var.name}-code-based-eval-executor-lambda"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${local.tag_name} Code-Based Eval Executor Lambda"
+  }
+}
+
+resource "aws_iam_role_policy" "code_based_eval_executor_lambda" {
+  count = var.enable_code_based_eval_executors ? 1 : 0
+
+  name = "${var.name}-code-based-eval-executor-lambda"
+  role = aws_iam_role.code_based_eval_executor_lambda[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "WriteFunctionLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = [
+          for log_group in values(aws_cloudwatch_log_group.code_based_eval_executor) : "${log_group.arn}:*"
+        ]
+      },
+      {
+        # AWS requires these permissions on "*" for VPC-attached Lambdas so the
+        # Lambda service can manage Hyperplane ENIs on behalf of the function.
+        # See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html#configuration-vpc-security
+        Sid    = "ManageLambdaVpcNetworkInterfaces"
+        Effect = "Allow"
+        Action = [
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeSubnets",
+          "ec2:UnassignPrivateIpAddresses",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "code_based_eval_executor" {
+  for_each = var.enable_code_based_eval_executors ? local.code_based_eval_executor_lambda_configs : {}
+
+  function_name = each.value.function_name
+  runtime       = each.value.runtime
+  handler       = each.value.handler
+  role          = aws_iam_role.code_based_eval_executor_lambda[0].arn
+
+  filename         = data.archive_file.code_based_eval_executor[each.key].output_path
+  source_code_hash = data.archive_file.code_based_eval_executor[each.key].output_base64sha256
+
+  architectures                  = ["arm64"]
+  memory_size                    = var.code_based_eval_executor_lambda_settings[each.key].memory_size
+  timeout                        = var.code_based_eval_executor_lambda_settings[each.key].timeout
+  reserved_concurrent_executions = var.code_based_eval_executor_lambda_settings[each.key].reserved_concurrent_executions
+
+  ephemeral_storage {
+    size = 512
+  }
+
+  tenancy_config {
+    tenant_isolation_mode = "PER_TENANT"
+  }
+
+  vpc_config {
+    security_group_ids = [aws_security_group.code_based_eval_executor_lambda[0].id]
+    subnet_ids         = module.code_based_eval_executor_vpc[0].private_subnets
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.code_based_eval_executor,
+    aws_iam_role_policy.code_based_eval_executor_lambda,
+  ]
+}
+
+resource "aws_iam_role_policy" "code_based_eval_executor_lambda_deny_function_code_vpc_eni_management" {
+  count = var.enable_code_based_eval_executors ? 1 : 0
+
+  name = "${var.name}-code-based-eval-executor-lambda-deny-code-eni"
+  role = aws_iam_role.code_based_eval_executor_lambda[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Match AWS's recommended least-privilege deny pattern: keep ENI management
+        # available to the Lambda service, but deny those EC2 API calls from function code.
+        # See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html#configuration-vpc-security
+        Sid    = "DenyFunctionCodeVpcNetworkInterfaceManagement"
+        Effect = "Deny"
+        Action = [
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeSubnets",
+          "ec2:UnassignPrivateIpAddresses",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "lambda:SourceFunctionArn" = [
+              for lambda_function in values(aws_lambda_function.code_based_eval_executor) : lambda_function.arn
+            ]
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "langfuse_code_based_eval_executor_invoke" {
+  count = var.enable_code_based_eval_executors ? 1 : 0
+
+  name = "code-based-eval-executor-invoke"
+  role = aws_iam_role.langfuse_irsa.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "InvokeCodeBasedEvalExecutors"
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction",
+        ]
+        Resource = [
+          for lambda_function in values(aws_lambda_function.code_based_eval_executor) : lambda_function.arn
+        ]
+      },
+    ]
+  })
+
+  depends_on = [aws_iam_role_policy.code_based_eval_executor_lambda_deny_function_code_vpc_eni_management]
+}

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -87,9 +87,21 @@ s3:
     prefix: "media/"
 EOT
 
-  additional_env_values = length(var.additional_env) == 0 ? "" : <<EOT
+  additional_env_values = (!var.enable_code_based_eval_executors && length(var.additional_env) == 0) ? "" : <<EOT
 langfuse:
   additionalEnv:
+%{if var.enable_code_based_eval_executors~}
+    - name: NEXT_PUBLIC_LANGFUSE_CODE_EVAL_ENABLED
+      value: "true"
+    - name: LANGFUSE_CODE_EVAL_DISPATCHER
+      value: "aws-lambda"
+    - name: LANGFUSE_CODE_EVAL_AWS_LAMBDA_PYTHON_FUNCTION_NAME
+      value: "${local.code_based_eval_executor_lambda_names.python}"
+    - name: LANGFUSE_CODE_EVAL_AWS_LAMBDA_NODE_FUNCTION_NAME
+      value: "${local.code_based_eval_executor_lambda_names.node}"
+    - name: LANGFUSE_CODE_EVAL_LOCAL_TIMEOUT_MS
+      value: "${var.code_eval_local_timeout_ms}"
+%{endif~}
 %{for env in var.additional_env~}
     - name: ${env.name}
 %{if env.value != null~}
@@ -109,6 +121,19 @@ langfuse:
 %{endif~}
 %{endif~}
 %{endfor~}
+EOT
+
+  code_eval_worker_values = var.enable_code_based_eval_executors == false ? "" : <<EOT
+langfuse:
+  worker:
+    pod:
+      additionalEnv:
+        - name: LANGFUSE_CODE_EVAL_EXECUTION_QUEUE_SHARD_COUNT
+          value: "${var.code_eval_execution_queue_shard_count}"
+        - name: LANGFUSE_CODE_EVAL_EXECUTION_WORKER_CONCURRENCY
+          value: "${var.worker_code_eval_execution_queue_processing_concurrency}"
+        - name: QUEUE_CONSUMER_CODE_EVAL_EXECUTION_QUEUE_IS_ENABLED
+          value: "true"
 EOT
 
   ingress_values    = <<EOT
@@ -208,6 +233,7 @@ resource "helm_release" "langfuse" {
     local.ingress_values,
     local.encryption_values,
     local.additional_env_values,
+    local.code_eval_worker_values,
     local.clickhouse_overwrite_values,
   ])
 
@@ -215,6 +241,7 @@ resource "helm_release" "langfuse" {
     kubernetes_namespace.langfuse,
     aws_iam_role.langfuse_irsa,
     aws_iam_role_policy.langfuse_s3_access,
+    aws_iam_role_policy.langfuse_code_based_eval_executor_invoke,
     aws_eks_fargate_profile.namespaces,
     kubernetes_persistent_volume.clickhouse_data,
     kubernetes_persistent_volume.clickhouse_zookeeper,
@@ -222,4 +249,3 @@ resource "helm_release" "langfuse" {
     helm_release.aws_load_balancer_controller
   ]
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,3 +44,8 @@ output "bucket_id" {
   description = "ID of the S3 bucket for Langfuse"
   value       = aws_s3_bucket.langfuse.id
 }
+
+output "code_based_eval_executor_lambda_function_names" {
+  description = "Code-based eval executor Lambda function names by runtime"
+  value       = var.enable_code_based_eval_executors ? local.code_based_eval_executor_lambda_names : {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,77 @@ variable "redis_multi_az" {
   default     = false
 }
 
+variable "enable_code_based_eval_executors" {
+  description = "Create tenant-isolated Lambda executors for code-based evals."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_cidr_block_code_based_evals" {
+  description = "CIDR block for the dedicated isolated code-based eval executor VPC."
+  type        = string
+  default     = "10.1.0.0/24"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr_block_code_based_evals, 0))
+    error_message = "vpc_cidr_block_code_based_evals must be a valid CIDR block."
+  }
+}
+
+variable "code_based_eval_executor_lambda_settings" {
+  description = "Per-runtime resource settings for code-based eval executor Lambdas. Lambda CPU is allocated proportionally to memory and cannot be configured directly."
+  type = object({
+    python = object({
+      memory_size                    = number
+      timeout                        = number
+      reserved_concurrent_executions = number
+    })
+    node = object({
+      memory_size                    = number
+      timeout                        = number
+      reserved_concurrent_executions = number
+    })
+  })
+  default = {
+    python = {
+      memory_size                    = 128
+      timeout                        = 2
+      reserved_concurrent_executions = 50
+    }
+    node = {
+      memory_size                    = 128
+      timeout                        = 2
+      reserved_concurrent_executions = 50
+    }
+  }
+
+  validation {
+    condition = alltrue([
+      for settings in values(var.code_based_eval_executor_lambda_settings) :
+      settings.memory_size >= 128 && settings.timeout >= 1 && settings.timeout <= 900 && settings.reserved_concurrent_executions >= 0
+    ])
+    error_message = "Each code-based eval executor Lambda must use at least 128 MB memory, a timeout between 1 and 900 seconds, and non-negative reserved concurrency."
+  }
+}
+
+variable "code_eval_local_timeout_ms" {
+  description = "Local timeout in milliseconds for code eval execution requests."
+  type        = number
+  default     = 2000
+}
+
+variable "code_eval_execution_queue_shard_count" {
+  description = "Shard count for the code eval execution queue. Do not decrease after enabling."
+  type        = number
+  default     = 1
+}
+
+variable "worker_code_eval_execution_queue_processing_concurrency" {
+  description = "Code eval execution queue processing concurrency for Langfuse worker pods."
+  type        = string
+  default     = "5"
+}
+
 # Additional environment variables
 variable "additional_env" {
   description = "Additional environment variables to set on Langfuse pods"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.79.0"
+      version = ">= 6.30.0, < 7.0"
+    }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.8"
     }
 
     random = {


### PR DESCRIPTION
## Summary

- Adds tenant-isolated Python and Node.js Lambda executors for code-based evals, packaged from bundled runner handlers.
- Wires the Langfuse Helm release to use the AWS Lambda code eval dispatcher and enables the code eval worker queue consumer behind a single module flag.
- Creates a dedicated no-internet executor VPC, Lambda IAM role, deny policy for function-code ENI management, and Langfuse IRSA invoke permissions.
- Documents the community-facing enablement path and exposes only the executor Lambda function names for debugging.

## Linear

- [LFE-9943](https://linear.app/langfuse/issue/LFE-9943/include-lambda-setup-in-public-self-hoster-setup)

## Major Decisions

- Keeps `enable_code_based_eval_executors` as the only code-based eval enable flag so community users do not have to coordinate separate infra and worker settings.
- Keeps the isolated eval VPC managed by the module, with only the CIDR block configurable to avoid customer network collisions.
- Exposes Lambda function names rather than ARNs or isolated VPC internals to avoid turning implementation details into public API.

## Review Focus

- Lambda tenant isolation and no-egress VPC/security group setup.
- Helm environment wiring for dispatcher, function names, queue shard count, and worker concurrency.
- Public module interface changes in `variables.tf`, `outputs.tf`, and README docs.
