### PR TITLE
ci: add terraform fmt and validate checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly run against freshly resolved providers, to catch provider
+    # releases that break the module even without any code change.
+    - cron: "23 6 * * 1"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    name: terraform fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - run: terraform fmt -check -diff -recursive
+
+  # Discovered rather than hardcoded, so adding or removing an example does not
+  # need a matching change here.
+  discover:
+    name: Discover configurations
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - id: dirs
+        run: |
+          dirs=$(for d in . examples/*/; do
+            d=${d%/}
+            ls "$d"/*.tf >/dev/null 2>&1 && printf '%s\n' "$d"
+          done | jq -R . | jq -sc .)
+          echo "Validating: $dirs"
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
+
+  validate:
+    name: validate (${{ matrix.dir }}, TF ${{ matrix.terraform }})
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported Terraform (required_version) and latest.
+        terraform: ["1.9.8", "latest"]
+        dir: ${{ fromJSON(needs.discover.outputs.dirs) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+      - run: terraform init -backend=false -input=false
+      - run: terraform validate

--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,8 @@ fabric.properties
 # Local .terraform directories
 **/.terraform/*
 
-examples/**/.terraform.lock.hcl
+# A shared module must not pin its consumers' provider versions.
+.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -246,20 +246,20 @@ This module creates a complete Langfuse stack with the following components:
 
 | Name       | Version |
 |------------|---------|
-| terraform  | >= 1.0  |
-| aws        | >= 5.0  |
-| kubernetes | >= 2.10 |
-| helm       | >= 2.5  |
+| terraform  | >= 1.9    |
+| aws        | >= 5.79.0 |
+| kubernetes | ~> 2.0    |
+| helm       | ~> 2.0    |
 
 ## Providers
 
 | Name       | Version |
 |------------|---------|
-| aws        | >= 5.0  |
-| kubernetes | >= 2.10 |
-| helm       | >= 2.5  |
-| random     | >= 3.0  |
-| tls        | >= 3.0  |
+| aws        | >= 5.79.0 |
+| kubernetes | ~> 2.0    |
+| helm       | ~> 2.0    |
+| random     | ~> 3.0    |
+| tls        | ~> 4.0    |
 
 ## Resources
 

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -75,10 +75,10 @@ resource "aws_rds_cluster_parameter_group" "postgres" {
 }
 
 resource "aws_rds_cluster_instance" "postgres" {
-  count              = var.postgres_instance_count
-  identifier         = "${var.name}-postgres-${count.index + 1}"
-  cluster_identifier = aws_rds_cluster.postgres.id
-  instance_class     = "db.serverless"
+  count               = var.postgres_instance_count
+  identifier          = "${var.name}-postgres-${count.index + 1}"
+  cluster_identifier  = aws_rds_cluster.postgres.id
+  instance_class      = "db.serverless"
   engine              = aws_rds_cluster.postgres.engine
   engine_version      = aws_rds_cluster.postgres.engine_version
   publicly_accessible = false

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,7 @@
 terraform {
-  required_version = ">= 1.0"
+  # 1.9 is the first release that lets a variable validation block reference
+  # another variable, which the subnet validations in variables.tf rely on.
+  required_version = ">= 1.9"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This repository had no CI. GCP and Azure both grew a `fmt` + `validate` workflow that has since caught real breakage (an unbounded provider constraint resolving to a new major, Terraform-floor incompatibilities), so this ports the same one here and fixes the two things it immediately flags.

## The workflow

`fmt -check -diff -recursive`, plus a `validate` matrix over the oldest supported Terraform and the latest, for the root module and every directory under `examples/`. The example list is discovered at runtime, so adding one needs no change here. It also runs weekly against freshly resolved providers, which is how an upstream provider release that breaks the module gets noticed before a user reports it.

## What it found

**The module never worked on the Terraform versions it claimed.** `variables.tf` gates `private_subnet_ids` and `public_subnet_ids` on `var.vpc_id`, and referencing another variable from a `validation` block was only allowed from Terraform 1.9. Everything below that in the declared `>= 1.0` range fails at `terraform init`:

```
Error: Invalid reference in variable validation
  on variables.tf line 35, in variable "private_subnet_ids":
  35:     condition = var.vpc_id == null || length(coalesce(var.private_subnet_ids, [])) > 0
  The condition for variable "private_subnet_ids" can only refer to the
  variable itself, using var.private_subnet_ids.
```

Verified locally: 1.3.10 and 1.8.5 both fail, 1.9.8 passes. So `required_version` moves to `>= 1.9`, which documents the real floor rather than changing what works — nobody on 1.0–1.8 has a working install to break.

**`postgresql.tf` was unformatted**, from the alignment left behind by #51.

## Also in here

- The gitignore only covered `examples/**/.terraform.lock.hcl`, so the root lock file was one `git add -A` from being committed and pinning every consumer's provider versions.
- The README Requirements and Providers tables had drifted from `versions.tf` on every row.

## Reviewer notes

The matrix floor (`1.9.8`) is deliberately tied to `required_version` — if that floor moves, this moves with it. And `terraform validate` does not talk to AWS, so nothing here needs credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)