### PR TITLE
fix: make the first apply reliable on a Fargate-only cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The `clickhouse_instance_count` variable was removed: the number of EFS access p
 | Name       | Version   |
 |------------|-----------|
 | terraform  | >= 1.9    |
-| aws        | >= 5.79.0 |
+| aws        | ~> 6.0    |
 | kubernetes | ~> 2.0    |
 | helm       | ~> 2.7    |
 
@@ -310,7 +310,7 @@ The `clickhouse_instance_count` variable was removed: the number of EFS access p
 
 | Name       | Version   |
 |------------|-----------|
-| aws        | >= 5.79.0 |
+| aws        | ~> 6.0    |
 | kubernetes | ~> 2.0    |
 | helm       | ~> 2.7    |
 | random     | ~> 3.0    |

--- a/clickhouse.tf
+++ b/clickhouse.tf
@@ -38,6 +38,7 @@ EOT
 
   depends_on = [
     aws_eks_fargate_profile.namespaces,
+    aws_eks_addon.coredns,
   ]
 }
 

--- a/eks.tf
+++ b/eks.tf
@@ -88,6 +88,40 @@ resource "aws_eks_fargate_profile" "namespaces" {
   }
 }
 
+# EKS installs CoreDNS configured for EC2 infrastructure, so on a Fargate-only
+# cluster its pods stay Pending on the eks.amazonaws.com/compute-type=fargate
+# taint. Nothing in the cluster resolves DNS until that is fixed: the AWS Load
+# Balancer Controller cannot reach STS, and the Langfuse pods cannot resolve
+# the database hostnames.
+#
+# Managing CoreDNS as an add-on lets EKS render the deployment for Fargate
+# itself, which is more durable than patching the annotation of an
+# EKS-managed object after the fact. The kube-system Fargate profile selects
+# on the namespace alone, so it already matches the CoreDNS pods.
+resource "aws_eks_addon" "coredns" {
+  cluster_name = aws_eks_cluster.langfuse.name
+  addon_name   = "coredns"
+
+  configuration_values = jsonencode({
+    computeType = "Fargate"
+  })
+
+  # CoreDNS is pre-installed by EKS, so the add-on adopts an object Terraform
+  # does not own.
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  # The add-on only reaches ACTIVE once its pods schedule, which needs the
+  # profile to exist first.
+  depends_on = [
+    aws_eks_fargate_profile.namespaces,
+  ]
+
+  tags = {
+    Name = "${local.tag_name} CoreDNS"
+  }
+}
+
 resource "aws_security_group" "eks" {
   name        = "${var.name}-eks"
   description = "Security group for Langfuse EKS cluster"

--- a/ingress.tf
+++ b/ingress.tf
@@ -318,7 +318,7 @@ resource "helm_release" "aws_load_balancer_controller" {
 
   set {
     name  = "region"
-    value = data.aws_region.current.id
+    value = data.aws_region.current.region
   }
 
   set {

--- a/ingress.tf
+++ b/ingress.tf
@@ -330,5 +330,8 @@ resource "helm_release" "aws_load_balancer_controller" {
     kubernetes_service_account.aws_load_balancer_controller,
     aws_iam_role.aws_load_balancer_controller,
     aws_eks_fargate_profile.namespaces,
+    # Without cluster DNS the controller cannot resolve sts.<region>.amazonaws.com
+    # and fails to assume its IRSA role.
+    aws_eks_addon.coredns,
   ]
 }

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -152,6 +152,7 @@ langfuse:
     className: alb
     annotations:
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
+      alb.ingress.kubernetes.io/certificate-arn: ${aws_acm_certificate_validation.cert.certificate_arn}
       alb.ingress.kubernetes.io/scheme: ${var.alb_scheme}
       alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/ssl-redirect: '443'

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -54,7 +54,7 @@ redis:
 s3:
   deploy: false
   bucket: ${aws_s3_bucket.langfuse.id}
-  region: ${data.aws_region.current.id}
+  region: ${data.aws_region.current.region}
   forcePathStyle: false
   eventUpload:
     prefix: "events/"

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -68,12 +68,6 @@ resource "aws_rds_cluster" "postgres" {
   }
 }
 
-resource "aws_rds_cluster_parameter_group" "postgres" {
-  name        = "${var.name}-postgres-parameter-group"
-  family      = "aurora-postgresql15"
-  description = "Parameter group for ${local.tag_name} Postgres"
-}
-
 resource "aws_rds_cluster_instance" "postgres" {
   count               = var.postgres_instance_count
   identifier          = "${var.name}-postgres-${count.index + 1}"

--- a/versions.tf
+++ b/versions.tf
@@ -5,8 +5,10 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.79.0"
+      source = "hashicorp/aws"
+      # Bounded deliberately: an open-ended constraint silently adopts the next
+      # provider major, which removes attributes this module uses.
+      version = "~> 6.0"
     }
 
     random = {

--- a/vpc.tf
+++ b/vpc.tf
@@ -94,7 +94,7 @@ resource "aws_ec2_tag" "public_subnet_cluster" {
 # VPC Endpoints for AWS services
 resource "aws_vpc_endpoint" "sts" {
   vpc_id             = local.vpc_id
-  service_name       = "com.amazonaws.${data.aws_region.current.name}.sts"
+  service_name       = "com.amazonaws.${data.aws_region.current.region}.sts"
   vpc_endpoint_type  = "Interface"
   subnet_ids         = local.private_subnets
   security_group_ids = [aws_security_group.vpc_endpoints.id]
@@ -110,7 +110,7 @@ resource "aws_vpc_endpoint" "s3" {
   count = local.private_route_table_ids != null ? 1 : 0
 
   vpc_id            = local.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_endpoint_type = "Gateway"
   route_table_ids   = local.private_route_table_ids
 


### PR DESCRIPTION
Four correctness fixes ahead of the 1.0 interface freeze. The first two are the ones that make `terraform apply` succeed on a fresh cluster without manual `kubectl` intervention; the last two are hygiene that has to happen in a major.

## The ALB never gets a certificate — fixes #63

The ingress asked the load balancer controller for an HTTPS listener but never named a certificate, leaving the controller to discover one by matching the ingress host. Discovery races the certificate validation happening in the same apply, and when it loses, **no ALB is created at all** — so `data.aws_lb.ingress` finds nothing and the apply dies:

```
Error: Search returned 0 results, please revise so only one is returned
  with data.aws_lb.ingress, on tls-certificate.tf line 58
```

Naming it explicitly also supplies the dependency edge that was missing: `aws_acm_certificate_validation.cert` was referenced by **nothing**, so Terraform was free to install the chart before the certificate existed. `local.ingress_values` now depends on it, confirmed in the graph.

## CoreDNS never schedules — fixes #47

EKS installs CoreDNS configured for EC2, so on a Fargate-only cluster its pods sit on the `eks.amazonaws.com/compute-type=fargate` taint and nothing in the cluster resolves DNS. That cascades exactly as reported: the load balancer controller can't reach STS to assume its IRSA role, and the Langfuse pods can't resolve their database hostnames. The README's answer was to `kubectl rollout restart` CoreDNS afterwards, which only helps once the deployment tolerates Fargate at all.

This manages CoreDNS as an add-on with `computeType = "Fargate"`, so EKS renders the deployment for Fargate itself. That is more durable than patching an annotation on an EKS-managed object, which is what #56 and #60 each proposed — #56 by shelling out to `aws` and `kubectl` through `local-exec`, which needs both CLIs on whatever runs the apply. The existing `kube-system` Fargate profile selects on namespace alone, so it already matches the CoreDNS pods and no extra profile is needed.

**The ordering matters as much as the config**, and I got this wrong at first: adding the add-on alone left nothing waiting on it, so Terraform could still install the controller before DNS worked. cert-manager and the load balancer controller now depend on it directly; the ClickHouse operator and the Langfuse release already chain off those two.

## `aws` was unbounded — breaking

`>= 5.79.0` means a fresh `init` silently adopts the next provider major. That is precisely how the Azure module's `main` stopped initialising when azurerm 5 landed, and it is worth closing before the interface is stable. Pinned `~> 6.0`, and all four `data.aws_region.current.{id,name}` call sites move to `.region` — both are deprecated in 6.x and `validate` was already warning about them. The module is now warning-free.

## A parameter group attached to nothing

`aws_rds_cluster_parameter_group.postgres` was created but never referenced — `aws_rds_cluster.postgres` sets no `db_cluster_parameter_group_name` — so it held no settings and did nothing. It also hardcoded `family = "aurora-postgresql15"` while `postgres_version` is configurable, so it silently contradicted the cluster it appeared to belong to.

## What I could not verify

None of this is verified against a live cluster — no AWS credentials here. `fmt`, `validate` on both matrix legs, and a cycle-free dependency graph are the extent of it, and for the two ordering fixes I read the resulting graph edges rather than trusting the `depends_on` I wrote.

The riskiest one to doubt is the CoreDNS add-on adopting an object EKS already created. It carries `resolve_conflicts_on_create = "OVERWRITE"`, which should make that safe, but the first apply against an existing cluster is where I would look for surprises. `addon_version` is deliberately unset so EKS picks its default for the cluster's Kubernetes version and the resource does not drift.

Closes #63, closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)