### PR TITLE
fix!: derive the last three IAM names from var.name (from #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,9 @@ The `clickhouse_instance_count` variable was removed: the number of EFS access p
 
 | Name                         | Description                                                                                                      | Type         | Default                                | Required |
 |------------------------------|------------------------------------------------------------------------------------------------------------------|--------------|----------------------------------------|:--------:|
+| helm_release_timeout        | Seconds to wait for the Langfuse Helm release to become ready                                                    | number       | 900                                    |    no    |
+| postgres_version            | PostgreSQL engine version to use                                                                                 | string       | "15.12"                                |    no    |
+| additional_env              | Additional environment variables to set on Langfuse pods                                                         | list(object) | []                                     |    no    |
 | name                         | Name prefix for resources                                                                                        | string       | "langfuse"                             |    no    |
 | domain                       | Domain name used for resource naming                                                                             | string       | n/a                                    |   yes    |
 | vpc_cidr                     | CIDR block for VPC                                                                                               | string       | "10.0.0.0/16"                          |    no    |

--- a/ingress.tf
+++ b/ingress.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller_assume_role_policy"
 
 resource "aws_iam_role" "aws_load_balancer_controller" {
   assume_role_policy = data.aws_iam_policy_document.aws_load_balancer_controller_assume_role_policy.json
-  name               = "aws-load-balancer-controller"
+  name               = "${var.name}-alb-controller"
 
   tags = {
     Name = "${local.tag_name} ALB"
@@ -28,7 +28,7 @@ resource "aws_iam_role" "aws_load_balancer_controller" {
 }
 
 resource "aws_iam_policy" "aws_load_balancer_controller" {
-  name        = "AWSLoadBalancerControllerIAMPolicy"
+  name        = "${var.name}-alb-controller"
   description = "IAM policy for AWS Load Balancer Controller"
 
   policy = jsonencode({

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -240,9 +240,9 @@ resource "helm_release" "langfuse" {
   chart      = "langfuse"
   namespace  = kubernetes_namespace.langfuse.metadata[0].name
 
-  # Fargate + EFS cold-start overhead means the default 300s is not enough.
-  # ClickHouse tables need ~60s to initialize after ZooKeeper becomes ready,
-  # and the web pod may crash-restart once before ClickHouse is fully ready.
+  # Fargate cold starts on EFS-backed volumes mean the default 300s is not
+  # enough: the release brings up ClickHouse and Keeper before the web pod can
+  # pass its probes, and the web pod may crash-restart once on the way.
   timeout = var.helm_release_timeout
 
   values = compact([

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -220,7 +220,7 @@ resource "random_bytes" "encryption_key" {
 resource "kubernetes_secret" "langfuse" {
   metadata {
     name      = "langfuse"
-    namespace = "langfuse"
+    namespace = kubernetes_namespace.langfuse.metadata[0].name
   }
 
   data = {

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -240,6 +240,11 @@ resource "helm_release" "langfuse" {
   chart      = "langfuse"
   namespace  = kubernetes_namespace.langfuse.metadata[0].name
 
+  # Fargate + EFS cold-start overhead means the default 300s is not enough.
+  # ClickHouse tables need ~60s to initialize after ZooKeeper becomes ready,
+  # and the web pod may crash-restart once before ClickHouse is fully ready.
+  timeout = var.helm_release_timeout
+
   values = compact([
     local.langfuse_values,
     local.clickhouse_values,

--- a/s3.tf
+++ b/s3.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "langfuse" {
 
 # Create IRSA role for Langfuse service account
 resource "aws_iam_role" "langfuse_irsa" {
-  name = "langfuse"
+  name = "${var.name}-irsa"
   path = "/kubernetes/"
 
   assume_role_policy = jsonencode({

--- a/variables.tf
+++ b/variables.tf
@@ -138,6 +138,12 @@ variable "app_version" {
   default     = "4.14.0"
 }
 
+variable "helm_release_timeout" {
+  description = "Seconds to wait for the Langfuse Helm release to become ready. Fargate + EFS cold starts and the 60s ClickHouse ZooKeeper initialization cycle require more time than Helm's default 300s."
+  type        = number
+  default     = 900
+}
+
 # Resource configuration variables
 variable "langfuse_cpu" {
   description = "CPU allocation for Langfuse containers"

--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,7 @@ variable "app_version" {
 }
 
 variable "helm_release_timeout" {
-  description = "Seconds to wait for the Langfuse Helm release to become ready. Fargate + EFS cold starts and the 60s ClickHouse ZooKeeper initialization cycle require more time than Helm's default 300s."
+  description = "Seconds to wait for the Langfuse Helm release to become ready. Fargate cold starts, and bringing up ClickHouse and Keeper on EFS-backed volumes, take longer than the Helm provider's default 300s."
   type        = number
   default     = 900
 }


### PR DESCRIPTION
Carries the breaking part of @jamesstonehill's #60 onto current `main`. Their branch is on a fork with `maintainerCanModify: false`, so the rebase could not be pushed to #60 itself.

**Rescoped twice since first opening**, both times narrowing it:

- The external-DNS feature (`skip_dns_setup`, `certificate_arn`, the ALB outputs) moved to #72 — it is purely additive, so it does not need to ride the major.
- The `name_prefix` conversion was replaced with parameterised names. See below.

What is left is the one genuinely breaking change plus two small fixes.

## Why not `name_prefix`

#60 converted all eight IAM resources to `name_prefix`. Checking each one, only three ever collided:

| Resource | Name on `main` | Collides on a second install? |
| --- | --- | --- |
| `aws_iam_role.eks` | `${var.name}-eks` | No — `var.name` already disambiguates |
| `aws_iam_role.fargate` | `${var.name}-fargate` | No |
| `aws_iam_policy.efs` | `${var.name}-efs` | No |
| `aws_iam_role.efs` | `${var.name}-efs-csi` | No |
| `aws_iam_role.aws_load_balancer_controller` | `aws-load-balancer-controller` | **Yes — fixed name** |
| `aws_iam_policy.aws_load_balancer_controller` | `AWSLoadBalancerControllerIAMPolicy` | **Yes — fixed name** |
| `aws_iam_role.langfuse_irsa` | `langfuse` | **Yes — fixed name** |
| `aws_iam_role_policy.langfuse_s3_access` | `s3-access` | No — inline role policy, scoped to its role |

So four conversions solved a problem `var.name` already solves, and one targeted a resource with no account-wide namespace at all. Deriving the three fixed names from `var.name` is strictly smaller and better:

- **Names stay predictable.** External trust policies, permission boundaries, SCPs and CloudTrail filters all reference role names; a random suffix breaks them.
- **No 38-character cap.** That cap only applies to a role `name_prefix`, because AWS reserves 26 characters for its suffix. With `${var.name}-alb-controller` the limit is 64, so the `var.name` length validation the earlier revision needed is gone — it was papering over a problem the approach itself introduced.
- **Three replacements instead of seven.**

What `name_prefix` additionally bought was the same `var.name` in two regions of one account. That is worth a deliberate knob if anyone asks for it, not an unpredictable suffix on everything — especially when the README already documents `name` as the way to run more than one installation.

## Also here

**`Fix namespace dependency issue`** (@jamesstonehill). `kubernetes_secret.langfuse` carried a literal `namespace = "langfuse"`, so there was no dependency edge on the namespace resource — the same latent ordering race the Azure module had. Still present on `main`.

**`Increase helm release timeout`** (@jamesstonehill). Adds `helm_release_timeout` (default 900s) on the Langfuse release, which still ran on the provider's default 300s after #66. This answers a question I left open there: I had declined to pick a number, since GCP hardcodes `1800` and Azure sets nothing. A variable is a better answer than either. Its comment described chart v1's ZooKeeper cycle, which chart v2 replaced with ClickHouse Keeper, so that is corrected.

## Dropped from #60

Three stale version bumps (chart `1.5.29` superseded by #66; the Kubernetes and Postgres defaults are a deliberate 1.0 decision, since EKS refuses multi-minor jumps and an Aurora major is an in-place upgrade); the chart-tarball-URL change, which discards the provider's `repository` + `version` semantics for a hardcoded GitHub release URL; the CoreDNS annotation, superseded by #70's add-on; and the Bedrock policy, which is a real feature but grants `aws-marketplace:Subscribe` and deserves its own review.

## Verification

`fmt` clean, root and both examples validate on both matrix legs. Nothing is verified against a live cluster.

The upgrade case is what to watch: the three replacements include the IRSA role the Langfuse service account assumes and the controller role the ALB depends on, so a 1.0 upgrade note should say this happens rather than leaving it to plan output.

Supersedes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)